### PR TITLE
 Distinguish between numbers with and without fractional component

### DIFF
--- a/json/src/JSON/Parser.idr
+++ b/json/src/JSON/Parser.idr
@@ -187,7 +187,7 @@ toToken : Cast String a => (a -> JSON) -> SnocList Char -> JSToken
 toToken toJSON = (Lit . toJSON . cast . cast {to = String})
 
 numberToken : SnocList Char -> JSToken
-numberToken l = case find (== '.') l of
+numberToken l = case find (\c =>  c == '.' || c == 'e' || c == 'E') l of
   Just _  => toToken JDouble l
   Nothing => toToken JInteger l
 

--- a/json/test/src/Main.idr
+++ b/json/test/src/Main.idr
@@ -55,6 +55,15 @@ prop_integerReverseRoundTrip = reverseRoundTrip $ integer $ exponentialFrom 0 (-
 prop_doubleReverseRoundTrip : Property
 prop_doubleReverseRoundTrip = reverseRoundTrip $ double $ exponentialDouble 0 1.0e50
 
+prop_exponentialNotationInteger : Property
+prop_exponentialNotationInteger = property $ parseJSON Virtual "1e3" === Right (JDouble 1000.0)
+
+prop_exponentialNotationInteger1 : Property
+prop_exponentialNotationInteger1 = property $ parseJSON Virtual "1e+3" === Right (JDouble 1000.0)
+
+prop_exponentialNotationDouble : Property
+prop_exponentialNotationDouble = property $ parseJSON Virtual "1e-3" === Right (JDouble 0.001)
+
 --------------------------------------------------------------------------------
 --          Errors
 --------------------------------------------------------------------------------
@@ -184,6 +193,9 @@ properties = MkGroup "JSON.Parser"
   , ("prop_err7", prop_err7)
   , ("prop_err8", prop_err8)
   , ("prop_err9", prop_err9)
+  , ("prop_exponentialNotationInteger", prop_exponentialNotationInteger)
+  , ("prop_exponentialNotationInteger1", prop_exponentialNotationInteger1)
+  , ("prop_exponentialNotationDouble", prop_exponentialNotationDouble)
   ]
 
 main : IO ()

--- a/json/test/src/Main.idr
+++ b/json/test/src/Main.idr
@@ -41,6 +41,19 @@ prop_roundTrip = property $ do
 
   parseJSON Virtual str === Right v
 
+
+reverseRoundTrip : Show a => Gen a -> Property
+reverseRoundTrip g = property $ do
+  n <- forAll g
+  let enc = show n
+  (map show $ parseJSON Virtual enc) === Right enc
+
+prop_integerReverseRoundTrip : Property
+prop_integerReverseRoundTrip = reverseRoundTrip $ integer $ exponentialFrom 0 (-0x100000000000000000000000000000000) 0x100000000000000000000000000000000
+
+prop_doubleReverseRoundTrip : Property
+prop_doubleReverseRoundTrip = reverseRoundTrip $ double $ exponentialDouble 0 1.0e50
+
 --------------------------------------------------------------------------------
 --          Errors
 --------------------------------------------------------------------------------
@@ -159,6 +172,8 @@ prop_err9 = testErr "-0012"
 properties : Group
 properties = MkGroup "JSON.Parser"
   [ ("prop_roundTrip", prop_roundTrip)
+  , ("prop_integerReverseRoundTrip", prop_integerReverseRoundTrip)
+  , ("prop_doubleReverseRoundTrip", prop_doubleReverseRoundTrip)
   , ("prop_err1", prop_err1)
   , ("prop_err2", prop_err2)
   , ("prop_err3", prop_err3)

--- a/json/test/src/Main.idr
+++ b/json/test/src/Main.idr
@@ -12,7 +12,8 @@ key = string (linear 1 10) printableAscii
 prim : Gen JSON
 prim = frequency
   [ (1, element [JNull, JBool True, JBool False])
-  , (5, JNumber <$> double (exponentialDouble 0 1.0e50))
+  , (5, JDouble <$> double (exponentialDouble 0 1.0e50))
+  , (5, JInteger <$> integer (exponentialFrom 0 (-0x100000000000000000000000000000000) 0x100000000000000000000000000000000))
   , (5, JString <$> string (linear 0 10) unicode)
   ]
 


### PR DESCRIPTION
Currently, parsing the number "1" and writing it out again yields "1.0". This asymmetry can be troublesome when sending messages to software using other parsers, as they might reject "1.0" as a valid integer.

This PR distinguishes between numbers that contain a fractional (or exponential) component and those that don't.

Used the [JSON spec](https://www.rfc-editor.org/rfc/rfc8259#section-6) for reference and inspiration.