### PR TITLE
Add missing dependency to parser-json.ipkg

### DIFF
--- a/json/parser-json.ipkg
+++ b/json/parser-json.ipkg
@@ -2,7 +2,8 @@ package parser-json
 version   = 0.1.0
 authors   = "stefan-hoeck"
 sourcedir = "src"
-depends   = parser
+depends   = elab-util
+          , parser
 
 brief     = "Total and efficient parser and lexer for the JSON file format"
 


### PR DESCRIPTION
I'm not sure why this would work sometimes and not others, but I did notice that I needed this dependency specified outside of `pack` builds.

Given that `parser-json` does depend on `elab-util` directly when it imports `Derive.Prelude`, I think this is an appropriate addition (i.e. it _happens to build_ via `pack` without this dependency specified rather than it _should build_ without this dependency specified).